### PR TITLE
CR-2152 #time 1h Add method that allows for specific queries

### DIFF
--- a/Model/Behavior/ElasticSearchIndexableBehavior.php
+++ b/Model/Behavior/ElasticSearchIndexableBehavior.php
@@ -141,6 +141,7 @@ class ElasticSearchIndexableBehavior extends ModelBehavior {
 		if (empty($config['table'])) {
 			throw new ElasticSearchIndexException('Missing the "table" configuration - this should be automatic based on Model->useTable');
 		}
+		$config['index'] .= '_'.$config['table']; ##ES 6 did away with type mapping.  Need to  make separate indexes per data type
 		// autosetup index & table mapping
 		if (!Cache::read("elasticsearchindexablebehavior_setup_{$config['table']}", 'default')) {
 			$this->autoSetupElasticSearchIndex($config);

--- a/Model/Behavior/ElasticSearchIndexableBehavior.php
+++ b/Model/Behavior/ElasticSearchIndexableBehavior.php
@@ -559,15 +559,16 @@ class ElasticSearchIndexableBehavior extends ModelBehavior {
 	 */
 	public function esSearchGetKeysByScore(Model $Model, $q = '', $findIndexOption = []) {
 		$results = $this->_esSearchRawResults($Model, $q, $findIndexOption);
-
 		// transform $results -> $return, an array with KEYS of association_key and VALUES of score.
 		// example: $return = [ 192460 => 0.64, 192453 => 0.48, 188010 => 0.37 ]
 		// ID "192460" is our best matching result with score of "0.64".
 		// ASSUMPTION:  Each association_key is unique per result returned from ES.
 		$return = [];
 		foreach (array_keys($results) as $i) {
-			if (!empty($results[$i]['association_key']) && !empty($results[$i]['association_key'][0])) {
+			if (!empty($results[$i]['association_key']) && is_array($results[$i]['association_key'])) {
 				$association_key = $results[$i]['association_key'][0];
+			} else if (!empty($results[$i]['association_key'])) {
+				$association_key = $results[$i]['association_key'];
 			} else {
 				// Association key not found.
 				continue;

--- a/Model/Behavior/ElasticSearchIndexableBehavior.php
+++ b/Model/Behavior/ElasticSearchIndexableBehavior.php
@@ -793,7 +793,7 @@ class ElasticSearchIndexableBehavior extends ModelBehavior {
 
         $results = $this->_esSearchRawResults($Model, $query, $additionalOptions);
 
-        return !empty($results) ? true : false;
+        return !empty($results);
 
     }
 

--- a/Model/Behavior/ElasticSearchIndexableBehavior.php
+++ b/Model/Behavior/ElasticSearchIndexableBehavior.php
@@ -776,4 +776,25 @@ class ElasticSearchIndexableBehavior extends ModelBehavior {
 		return $query;
 	}
 
+    /**
+     * Method used to pass in a query and check if the ES term exists based on that criteria
+     * Allows for specific matches on a keys, eg.
+     * { "_source": true, "query" : { "term" : { "association_key" : "160524"  } } }
+     *
+     * @param Model $Model
+     * @param string $query
+     * @return bool
+     */
+    public function hasEsTerm(Model $Model, $query = '') {
+
+        $additionalOptions = array(
+            'size' => 1
+        );
+
+        $results = $this->_esSearchRawResults($Model, $query, $additionalOptions);
+
+        return !empty($results) ? true : false;
+
+    }
+
 }

--- a/Model/Behavior/ElasticSearchIndexableBehavior.php
+++ b/Model/Behavior/ElasticSearchIndexableBehavior.php
@@ -89,9 +89,9 @@ class ElasticSearchIndexableBehavior extends ModelBehavior {
 	 * @var array
 	 */
 	public $mapping = array(
-		'association_key' => array('type' => 'string', 'store' => true),
-		'model' => array('type' => 'string', 'store' => true, 'boost' => 0.2),
-		'data' => array('type' => 'string', 'store' => true),
+		'association_key' => array('type' => 'text', 'store' => true),
+		'model' => array('type' => 'text', 'store' => true, 'boost' => 0.2),
+		'data' => array('type' => 'text', 'store' => true),
 		'created' => array('type' => 'date', 'store' => false, 'format' => 'yyyy-MM-dd HH:mm:ss||yyyy/MM/dd'),
 		'modified' => array('type' => 'date', 'store' => false, 'format' => 'yyyy-MM-dd HH:mm:ss||yyyy/MM/dd'),
 	);


### PR DESCRIPTION
Method allows for specific queries against a desired _source key
instead of using the default fuzzy matching. For example
{"_source":true, "query": {"term" : {"association_key" : "2"}}} as
a query would only try to match on an association_key of 2 instead
of any association_key that contains a 2 within it.